### PR TITLE
6장 comp-comm 예제 변화감지 버그 수정

### DIFF
--- a/ch06/comp-comm/src/app/check-list/check-list.component.ts
+++ b/ch06/comp-comm/src/app/check-list/check-list.component.ts
@@ -24,7 +24,7 @@ export class CheckListComponent implements OnInit {
 
   onChecked(isChecked, checkedItem: CheckItem) {
     checkedItem.isChecked = isChecked
-    this.curCheckedItem = checkedItem;
+    this.curCheckedItem = JSON.parse(JSON.stringify(checkedItem));
     this.checkListDataService.checkItem(checkedItem);
   }
 


### PR DESCRIPTION
Angular의 변화감지는 기본적으로 Reference 비교 입니다.
참고: https://github.com/angular/angular/blob/master/packages/core/src/util.ts#L54-L56
동일 아이템을 체크/해제할 경우 Reference가 변경되지 않아서 예제 코드가 정상 작동하지 않았습니다.